### PR TITLE
excluded /tools from published site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,4 @@ defaults:
 layouts_dir: 2018/_layouts
 includes_dir: 2018/_includes
 data_dir: 2018/_data
-exclude: ["README.*"]
+exclude: ["README.*","/tools/**"]


### PR DESCRIPTION
Just that, added the `/tools` directory to the list of excluded resources by Jekyll.
That way they are not processed nor published.