### PR TITLE
added message to use 512x512 images for speakers picture

### DIFF
--- a/2018/callForPapers.html
+++ b/2018/callForPapers.html
@@ -142,6 +142,7 @@ bodyClass: home page-template-default page page-id-7 eventstation-class  eventst
                                             </div>
                                             <div class="form-group">
                                                 <label for="senderName0">Picture (URL) *:</label>
+                                                <div>Please, ensure that the image is 512 x 512. This will help us a lot and avoid any resizing on our side.</div>
                                                 <input required type="text" class="form-control" name="picture0" id="picture0">
                                             </div>
                                             <div class="form-group">


### PR DESCRIPTION
Since we cannot enforce it in the backend (yet).
I wrote a "recomendation" message that tries to appeal to the speakers "kindness". wdyt?

The size 512x512 is based on the usage sizes of last year. This is the most used (14 of 59).