### PR TITLE
Removed unnecessary travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-sudo: false
-rvm: 2.4.2
-script: bundle exec rake deploy
-branches:
-  only:
-  - master
-  global:
-    secure: f0ZJDQEikNktFyTYOIIoetIaar1PCdpZ2ZnDtcMbJwEDksyzhuRObLJRnW7PIw9NTOrYitbdsxU9xn8CLxnsMxTFMYyt9Q8pNYJXa8LjJTpkw+UCca37kKRSpujAr/9gKxpw+O2x+ZRmB3w2x5ncWL7fLRaDKL/A1+asTVI43iwnbN2L+soOmpOLCXjcIvbPJ6zQc8Z3EU7znLsaWOfnU6XKu2sjb147XiB+heRuuVgm/hG3/PQNZuHaaPlPn2yE5KaQc/yN3P5Ypj/4ogg2DDey2WVwYKRcUmyJVth9awwviytiuoe+ErsZgYZZO+rl2qXwYPxxvmIRo30RqznROnmKYvXLwVlzWiqwEGiNZsTWrxz0N2ytqcvH8HTzI6Qa3vQ36ncBTrQeed/8e9r/ENHUFhaGxsaeqQODrbrhiu8WBVm7YtfGBA7ztTMFS5nUeUKSygQDzpF2dXXMZjCA+7q6Ji8L74YbijTDH++uq2876jSX0IDj3mMhN/hlakOb8S1qzOodpBxdX3TqyIuO/agYglOeOmyXJlmiS/d4vGIuCiz76vXDlxzAmDC+5QZf6fMcUqyrHQ2jNjXPj0xFEQDhvXZJQiBq7PWNYj7xYaY09npsMxhKH+dO7WmskWCoTcuUac7GmDlCQ0p+aCQZl/0aKmO6s1R9BZM2uPURKNc=

--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,10 @@ If you want to build the site with Ruby 2.5.x, skip `bundler` and install the ge
 === Testing it locally
 
 Just fork the repo, open a shell, place yourself in the root and run
+ 
+ $ bundle exec jekyll serve
+
+of just
 
  $ jekyll serve
 
@@ -50,24 +54,4 @@ The server will stay up and self-update automatically.
 
 You can publish the site in your cloned repo to see the result of your changes.
 
-First, enable GitHub pages in your fork and set it to publish to the gh-pages branch.
-Then, build the site and commit the generated files under `_site` to the `gh-pages` branch.
-
-[NOTE]
-====
-Automatic publishing won't work in cloned repos due to the use of a special token in the TravisCI configuration.
-See https://github.com/jirutka/rake-jekyll#setup-for-github-pages-and-travis-ci for details.
-====
-
-== Publishing
-
-=== Publishing the site
-
-All changes to `master` are automatically published using a link:https://travis-ci.org/[TravisCI] build.
-
-This means, the site will be updated when:
-
-* changes are directly pushed into master.
-* a branch is merged into master.
-
-Once a changes are merged, you can check the TravisCI publishing job in https://travis-ci.org/barcelonajug/jbcnconf_web/.
+First, enable GitHub pages in your forked repository and set it to publish to the gh-pages branch.


### PR DESCRIPTION
Once confirmed GHPages publises the site automatically, the TravisCS is not necessary and removed.