### PR TITLE
Support for cross domain tracking in Google Analytics

### DIFF
--- a/2019/_includes/scripts_top.html
+++ b/2019/_includes/scripts_top.html
@@ -49,7 +49,9 @@
         m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-    ga('create', 'UA-59851291-1', 'auto');
+    ga('create', 'UA-59851291-1', 'auto', {'allowLinker': true});
+    ga('require', 'linker');
+    ga('linker:autoLink', ['tickets.jbcnconf.com']);
     ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
Following the official documentation (https://support.google.com/analytics/answer/1034342) we have to change our tracking code for supporting cross domain tracking in Google Analytics.
This should be approved with [the following PR with the changes on the backend part](https://github.com/barcelonajug/alf.io/pull/1)
