### PR TITLE
fix talk url in speakers page

### DIFF
--- a/2019/speakers.html
+++ b/2019/speakers.html
@@ -55,19 +55,19 @@ bodyClass: home page-template-default page page-id-7 eventstation-class  eventst
                                       {% for talk in site.data.talks.items %}
                                         {% if speaker.ref == talk.speakers[0] or speaker.ref == talk.speakers[1] %}
                                           {% capture talkTitle %}{{ talk.title }}{% endcapture %}
+                                          {% capture talkId %}{{ talk.id }}{% endcapture %}
                                         {% endif %}
-                                    {% endfor %}
+                                      {% endfor %}
 
                                     <div class="item col-md-4" style="height:550px;">
                                         <div class="speaker-item-header"
                                              style="background-image:url('{{ base }}/{{ speaker.image }}');">
                                             <div class="speaker-item-topic-wrapper">
-                                                <a href="{{ base }}/{{ speaker.url }}">
+                                                <a href="{{ base }}/infoTalk.html?id={{ talkId }}">
                                                     <h4 class="speaker-item-topic-title">
                                                         {{ talkTitle }}
                                                     </h4>
                                                 </a>
-
                                             </div>
                                         </div>
                                         <div class="speaker-item-body" style="height:195px">


### PR DESCRIPTION
Fixes the url over the talk title in the "all speakers" page, which is currently pointing to the speaker's page.
It now points to the talk's page.

known issues: page only shows one talk, in case a speaker has more than 1.