### PR TITLE
 Default day on schedule set on Monday instead of Wednesday

### DIFF
--- a/2019/assets/js/schedule.js
+++ b/2019/assets/js/schedule.js
@@ -37,7 +37,9 @@
 
 
         var day = window.location.hash.toLowerCase();
-        if (day.indexOf("#") !== -1) {
+        if (day.indexOf("#") === -1) {
+            day = 'monday';
+        } else {
             day = day.replace("#", "");
         }
         if (day && (day === 'wednesday' || day === 'tuesday' || day === 'monday')) {


### PR DESCRIPTION
When an hash is not defined the default day is Monday.
During the conference days a different logic will be applied, as before this fix