### PR TITLE
fix: remove duplicated link

### DIFF
--- a/2022/_data/menu.yml
+++ b/2022/_data/menu.yml
@@ -26,8 +26,6 @@ items:
       href: "/offers.html"
 - label: Become Sponsor
   href: "/become-sponsor.html"
-- label: Venue
-  href: "/java-barcelona-venue.html"
 - label: Travel
   href: "/#Travel"
   items:


### PR DESCRIPTION
Remove duplicated **Venue** link on the top menu