### PR TITLE
Update meta information for Jbcnconf 2022

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ defaults:
       layout: "default"
       #default values for meta tags. can be configured per page in each template
       title: "JBCNConf - The first Java and JVM conference in Spain"
-      description: "The first big Java and JVM conference in Spain. Barcelona will host this great event next 6th to 8th of July 2020. 3 days to share knowledge and experiences, to meet enthusiasts and geeks, and to learn about new technologies."
+      description: "The first big Java and JVM conference in Spain. Barcelona will host this great event next 18th to 20th of July 2022. 3 days to share knowledge and experiences, to meet enthusiasts and geeks, and to learn about new technologies."
       keywords: "java barcelona, jug barcelona, jbcnconf, java barcelona conference"
 layouts_dir: 2022/_layouts
 includes_dir: 2022/_includes


### PR DESCRIPTION
This PR fixes the wrong meta SERP description with information for the jbcnconf 2022.