### PR TITLE
Fix typo in talk title

### DIFF
--- a/2022/_data/talks.json
+++ b/2022/_data/talks.json
@@ -476,7 +476,7 @@
     },
     {
       "id": "622916e656274e0bddf0079b",
-      "title": "Seamless SSO workshop : KEYCLAOK + SPRING + VUE.JS + LDAP",
+      "title": "Seamless SSO workshop : KEYCLOAK + SPRING + VUE.JS + LDAP",
       "languages": [
         "eng"
       ],


### PR DESCRIPTION
Seems like a non intended typo: KEYCLAOK -> KEYCLOAK

https://www.jbcnconf.com/2022/infoSpeaker.html?ref=5a014096a2b2b36a9a4058dd045242f74f71d32a