### PR TITLE
Remove unused Ruby dependencies to fix security notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gem 'github-pages'
 gem "jekyll", "~> 3.9.2"
-gem 'rake'
-gem 'rake-jekyll'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,9 +242,6 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
     racc (1.6.0)
-    rake (10.5.0)
-    rake-jekyll (1.1.0)
-      rake (~> 10.0)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -282,8 +279,6 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll (~> 3.9.2)
-  rake
-  rake-jekyll
   tzinfo-data
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,0 @@
-require 'rake-jekyll'
-
-Rake::Jekyll::GitDeployTask.new(:deploy)

--- a/jekyll.gradle
+++ b/jekyll.gradle
@@ -11,7 +11,6 @@ dependencies {
     jrubyExec 'rubygems:tzinfo-data:1.2019.1'
     jrubyExec 'rubygems:kramdown:1.16.2'
     jrubyExec 'rubygems:rouge:3.1.1'
-    jrubyExec 'rubygems:rake:10.5.0'
     jrubyExec 'rubygems:public_suffix:3.0.1'
     jrubyExec 'rubygems:addressable:2.5.2'
     jrubyExec 'rubygems:concurrent-ruby:1.0.5'
@@ -25,7 +24,6 @@ dependencies {
     jrubyExec 'rubygems:liquid:4.0.0'
     jrubyExec 'rubygems:pathutil:0.16.1'
     jrubyExec 'rubygems:safe_yaml:1.0.4'
-    jrubyExec 'rubygems:rake-jekyll:1.1.0'
 }
 
 task jekyll( type : JRubyExec ) {


### PR DESCRIPTION
We don't need to set rake in the Gemfile since we don't use it.


Shushing GH notification...

![image](https://user-images.githubusercontent.com/5781153/169650063-0a5fbc14-ba51-44d9-8c14-9733a49cca0c.png)
